### PR TITLE
[rpm] Pass the target platform to configure again. Fixes JB#56068

### DIFF
--- a/rpm/0021-Revert-Don-t-set-target-in-configure-RhBug-458648.patch
+++ b/rpm/0021-Revert-Don-t-set-target-in-configure-RhBug-458648.patch
@@ -1,0 +1,25 @@
+From 77fb9a2bdc801eb264b04b11ed057d672a8b2e37 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Bidar?= <bjorn.bidar@jolla.com>
+Date: Mon, 25 Oct 2021 21:21:40 +0300
+Subject: [PATCH] Revert "Don't set --target in %configure (RhBug:458648)"
+
+This reverts commit de218d7069294c615dd45cf274dd109ebbdce335.
+---
+ macros.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/macros.in b/macros.in
+index 35c8cf9df..a04b28621 100644
+--- a/macros.in
++++ b/macros.in
+@@ -1062,6 +1062,7 @@ package or when debugging this package.\
+ %configure \
+   %{set_build_flags}; \
+   %{_configure} --host=%{_host} --build=%{_build} \\\
++	--target=%{_target_platform} \\\
+ 	--program-prefix=%{?_program_prefix} \\\
+ 	--disable-dependency-tracking \\\
+ 	--prefix=%{_prefix} \\\
+-- 
+2.33.1
+

--- a/rpm/rpm.spec
+++ b/rpm/rpm.spec
@@ -24,6 +24,7 @@ Patch18: 0018-include-plugin-header.patch
 # so then it could probably be removed.
 Patch19: 0019-Limit-to-4-threads-for-lzma-compression-to-make-sure.patch
 Patch20: 0020-Do-not-fail-on-magic-errors.patch
+Patch21: 0021-Revert-Don-t-set-target-in-configure-RhBug-458648.patch
 
 Url: http://www.rpm.org/
 


### PR DESCRIPTION
Upstream removed the passing of --target=%{_target_platform} to
configure. We need to revert that since without it the --target switch
passed to rpm is no longer enforced because then config.guess is used
to set the target platform.

For more see the upstream issue here:
https://github.com/rpm-software-management/rpm/issues/1810

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>