### PR TITLE
[packaging] Don't explicitly require lib dependencies. JB#57054

### DIFF
--- a/rpm/rpm.spec
+++ b/rpm/rpm.spec
@@ -37,8 +37,6 @@ License: GPLv2+
 Requires: curl
 Requires: coreutils
 Requires: db4-utils
-Requires: liblua
-Requires: openssl-libs
 BuildRequires: db4-devel
 BuildRequires: meego-rpm-config
 BuildRequires: autoconf


### PR DESCRIPTION
Fixes:
rpm.i486: E: explicit-lib-dependency liblua
rpm.i486: E: explicit-lib-dependency openssl-libs
You must let rpm find the library dependencies by itself. Do not put unneeded
explicit Requires: tags.