### PR TITLE
Migrate to NDB database backend. Fixes JB#63646

### DIFF
--- a/rpm/0027-Use-NDB-as-the-default-database-backend.patch
+++ b/rpm/0027-Use-NDB-as-the-default-database-backend.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matti Viljanen <matti.viljanen@jolla.com>
+Date: Fri, 15 Aug 2025 11:47:12 +0300
+Subject: [PATCH] Use NDB as the default database backend
+
+---
+ macros.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/macros.in b/macros.in
+index 5c41d6f6e..cac536d33 100644
+--- a/macros.in
++++ b/macros.in
+@@ -624,7 +624,7 @@ package or when debugging this package.\
+ # sqlite Sqlite database
+ # dummy dummy backend (no actual functionality)
+ #
+-%_db_backend	      bdb
++%_db_backend	      ndb
+ 
+ #
+ #	Macros used to configure Berkley db parameters.

--- a/rpm/rpm-python.spec
+++ b/rpm/rpm-python.spec
@@ -34,6 +34,7 @@ BuildRequires: lua-devel >= 5.1
 BuildRequires: libcap-devel
 BuildRequires: xz-devel >= 4.999.8
 BuildRequires: libzstd-devel
+BuildRequires: sqlite-devel
 
 %description
 The RPM Package Manager (RPM) is a powerful command line driven
@@ -64,6 +65,7 @@ export CPPFLAGS CFLAGS LDFLAGS
     --with-lua \
     --with-cap \
     --disable-inhibit-plugin \
+    --enable-ndb \
     --enable-python
 
 %make_build

--- a/rpm/rpm.spec
+++ b/rpm/rpm.spec
@@ -113,7 +113,8 @@ export CPPFLAGS CFLAGS LDFLAGS
     --enable-zstd \
     --with-lua \
     --with-cap \
-    --disable-inhibit-plugin
+    --disable-inhibit-plugin \
+    --enable-ndb
 
 %make_build
 
@@ -184,7 +185,11 @@ if [ -x /usr/bin/systemctl ]; then
 fi
 
 %posttrans
-if [ -f /var/lib/rpm/Packages ]; then
+# Rebuild database after RPM update.
+# Migrate from Berkeley DB to RPM NDB format.
+# Packages: bdb
+# Packages.db: ndb
+if [ -f /var/lib/rpm/Packages -o -f /var/lib/rpm/Packages.db ]; then
     touch /var/lib/rpm/.rebuilddb
 fi
 

--- a/rpm/shared.inc
+++ b/rpm/shared.inc
@@ -21,8 +21,9 @@ Patch23: 0023-Add-brp-remove-la-files-script.patch
 Patch24: 0024-Also-delete-symbol-links-that-could-point-to-la-file.patch
 Patch25: 0025-Exclude-usr-share-info-dir-from-check-files.patch
 
-# Remove this when updating rpm. JB#62519
+# Remove these when updating rpm. JB#62519
 Patch26: 0026-Use-external-debuginfo-tooling.patch
+Patch27: 0027-Use-NDB-as-the-default-database-backend.patch
 
 # Partially GPL/LGPL dual-licensed and some bits with BSD
 # SourceLicense: (GPLv2+ and LGPLv2+ with exceptions) and BSD 


### PR DESCRIPTION
We have been sticking to DBD backend until now. SQLite has been the default option since rpm 4.17 where DBD was also removed completely. NDB is still maintained, and introducing SQLite suppor would introduce additional dependencies, so let's migrate to NDB.